### PR TITLE
fix: multi word matching

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,58 @@
+name: Run UnitTests
+on:
+  pull_request:
+    branches:
+      - dev
+    paths-ignore:
+      - 'ovos_yes_no_solver/version.py'
+      - 'examples/**'
+      - '.github/**'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'CHANGELOG.md'
+      - 'MANIFEST.in'
+      - 'README.md'
+      - 'scripts/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'ovos_yes_no_solver/version.py'
+      - 'examples/**'
+      - '.github/**'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'CHANGELOG.md'
+      - 'MANIFEST.in'
+      - 'README.md'
+      - 'scripts/**'
+  workflow_dispatch:
+
+jobs:
+  unit_tests:
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: [3.9]
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt install python3-dev swig libssl-dev
+          python -m pip install build wheel
+      - name: Install test dependencies
+        run: |
+          pip install -r tests.txt
+      - name: Install repo
+        run: |
+          pip install -e .
+      - name: Run unittests
+        run: |
+          pytest --cov=ovos_yes_no_solver --cov-report xml tests

--- a/ovos_yes_no_solver/res/pt/yesno.json
+++ b/ovos_yes_no_solver/res/pt/yesno.json
@@ -29,16 +29,26 @@
     "obviamente",
     "obvio",
     "facto",
-    "fato"
+    "fato",
+    "certeza"
   ],
   "neutral_no": [
+    "sem hipótese",
+    "não há hipótese",
+    "mentindo",
+    "mentir",
+    "enganar",
+    "enganado",
+    "enganada",
+    "indesejável",
     "mentira",
+    "mentiras",
     "falso",
     "inadequado",
     "mentira",
     "mentiroso",
     "erro",
-    "(enganado|enganada)",
-    "errado"
+    "errado",
+    "errada"
   ]
 }

--- a/tests.txt
+++ b/tests.txt
@@ -1,0 +1,5 @@
+coveralls>=1.8.2
+flake8>=3.7.9
+pytest>=5.2.4
+pytest-cov>=2.8.1
+cov-core>=1.15.0

--- a/tests/test_sentences_pt.json
+++ b/tests/test_sentences_pt.json
@@ -32,7 +32,7 @@
     "sim, eu não quero isso com certeza",
     "não, eu obviamente odeio isso",
     "isso é certamente indesejável",
-    "não, é mentira",
+    "são mentiras",
     "ele está a mentir",
     "é mentira",
     "você está enganado",

--- a/tests/test_yn_pt.py
+++ b/tests/test_yn_pt.py
@@ -8,12 +8,12 @@ class TestYesNo(unittest.TestCase):
     def setUp(self):
         self.solver = YesNoSolver()
         # Load the test data from the JSON file
-        with open(os.path.join(os.path.dirname(__file__), "test_sentences_en.json"), "r") as f:
+        with open(os.path.join(os.path.dirname(__file__), "test_sentences_pt.json"), "r") as f:
             self.test_data = json.load(f)
 
     def test_yesno(self):
         def test_utt(text, expected):
-            res = self.solver.match_yes_or_no(text, "en-us")
+            res = self.solver.match_yes_or_no(text, "pt-pt")
             print(text, expected, res)
             self.assertEqual(res, expected)
 


### PR DESCRIPTION
refactor to use a regex instead of matching word by word, allowing multi word translations to work properly, eg, "please" becomes "por favor" in portuguese and wouldn't match otherwise

enable pt unittests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved text normalization and response matching in the YesNoSolver, including language-specific handling for Portuguese.
	- Expanded vocabulary for neutral responses in Portuguese.
	- Added a new test suite for Portuguese language inputs, enhancing testing coverage.
	- Introduced a GitHub Actions workflow for automated unit testing.

- **Bug Fixes**
	- Enhanced logic for detecting "yes" and "no" responses, including better handling of double negatives.

- **Chores**
	- Added debugging print statements in test cases for easier tracking of evaluations.
	- Updated testing dependencies to improve code quality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->